### PR TITLE
currentOrganizer クエリを実行して、アクセストークンの有効性をサーバー側で検証

### DIFF
--- a/frontend/organizer-ui/src/hooks/useAuth.ts
+++ b/frontend/organizer-ui/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useCurrentOrganizerQuery } from "../graphql/generated";
 
 type UserInfo = {
   accessToken: string;
@@ -13,6 +14,7 @@ export const useAuth = () => {
   const [user, setUser] = useState<UserInfo | null>(null);
   const [initialized, setInitialized] = useState(false);
 
+  // 初回 localStorage から読み込み
   useEffect(() => {
     const stored = localStorage.getItem("userInfo");
     if (stored) {
@@ -22,6 +24,29 @@ export const useAuth = () => {
     }
     setInitialized(true);
   }, []);
+
+  // 🔍 サーバーでトークン検証（token があるときのみ実行）
+  const [{ data, error }] = useCurrentOrganizerQuery({
+    pause: !token,
+  });
+
+  useEffect(() => {
+    if (error?.message.includes("Unauthorized")) {
+      logout(); // トークンが無効ならログアウト
+    } else if (data?.currentOrganizer) {
+      // 🔁 サーバーの正しい情報で user を上書き（email, role, tenantId）
+      setUser((prev) =>
+          prev
+              ? {
+                ...prev,
+                email: data.currentOrganizer.email,
+                role: data.currentOrganizer.role,
+                tenantId: data.currentOrganizer.tenantId,
+              }
+              : null
+      );
+    }
+  }, [data, error]);
 
   const login = (userInfo: UserInfo) => {
     localStorage.setItem("userInfo", JSON.stringify(userInfo));


### PR DESCRIPTION
## 🔍 概要
- useAuth フックに currentOrganizer クエリを統合し、アクセストークンの有効性をサーバー側で検証可能な構成とした。
- トークンが無効（期限切れ・不正）な場合には自動的にログアウトされ、ユーザー状態はサーバーから取得した正確な情報で上書き・同期されるようになっている。

## 🧩 なぜ必要か
- 従来の認証状態は localStorage の値のみに依存しており、アクセストークンの期限切れや不正な改ざんを検知できなかった。
- currentOrganizer クエリを活用することで、トークンの整合性とユーザー情報の信頼性を担保し、サーバーとクライアントの認証状態を一貫性のあるものとする必要がある。

## ⚠️ 対応しないと発生する問題
- 期限切れのトークンでもログイン済みと誤認される
- 不正に改ざんされたトークンでも保護された画面が表示され、セキュリティ上のリスクとなる
- ログイン後にサーバー側で変更されたロールやメールアドレスがクライアントに反映されない
- 実際には未認証であるにもかかわらず、保護されたページにアクセス可能となる恐れがある

---

### before
![Screenshot 2025-07-01 at 8 16 32](https://github.com/user-attachments/assets/07cb1275-23bc-40d9-ab08-1bc0626ad5e0)

![Screenshot 2025-07-01 at 8 16 56](https://github.com/user-attachments/assets/72a5458a-1684-455b-bdf6-bb89a9d51d43)


### after
![Screenshot 2025-07-01 at 8 14 59](https://github.com/user-attachments/assets/aca53560-66be-4202-8ca5-2d5028fd0aea)


![Screenshot 2025-07-01 at 8 15 28](https://github.com/user-attachments/assets/70547df8-317d-4122-bbb7-d63339d49dc8)
